### PR TITLE
Fix items index

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,11 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     @user.update(user_params)
-    redirect_to merchants_path, notice: "User account has been disabled"
+    if current_user == "merchant"
+      redirect_to merchants_path, notice: "User account has been disabled"
+    else
+      redirect_to "/users?display=all", notice: "User account has been disabled"
+    end 
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   def index
-    @items = Item.all
+    @items = Item.where(active: true)
   end
 
   def show

--- a/spec/features/user_admin_can_enable_disable_users_spec.rb
+++ b/spec/features/user_admin_can_enable_disable_users_spec.rb
@@ -10,8 +10,8 @@ describe 'when an admin user visits the user index page' do
     fill_in :password, with: "admin"
     click_button "Log In"
 
-    visit users_path
-
+    click_link "All Users"
+  
     within("#user#{user.id}") do
       click_button "Disable"
     end
@@ -37,11 +37,11 @@ describe 'when an admin user visits the user index page' do
     user = create(:user, email: "name", password: "name")
     visit root_path
     click_link "Log In"
-    fill_in :email, with: "admin"
-    fill_in :password, with: "admin"
+    fill_in :email, with: admin.email
+    fill_in :password, with: admin.password
     click_button "Log In"
 
-    visit users_path
+    click_link "All Users"
 
     within("#user#{user.id}") do
       click_button "Disable"

--- a/spec/features/user_sees_items_index_spec.rb
+++ b/spec/features/user_sees_items_index_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 describe 'when any user visits the items index page' do
-  it 'displays all item information' do
+  it 'displays all item information for enabled items' do
     user = create(:user)
-    item_1, item_2 = create_list(:item, 2, user: user)
+    item_1 = create(:item, user: user, active: true)
+    item_2 = create(:item, user: user, active: false)
 
     visit root_path
     click_on "All Items"
@@ -14,10 +15,8 @@ describe 'when any user visits the items index page' do
     expect(page).to have_css("img[src='#{item_1.image}']")
     expect(page).to have_content(item_1.inventory_count)
     expect(page).to have_content(item_1.price)
-    expect(page).to have_link("#{item_2.name}")
-    expect(page).to have_content(item_2.user.name)
-    expect(page).to have_css("img[src='#{item_2.image}']")
-    expect(page).to have_content(item_2.inventory_count)
-    expect(page).to have_content(item_2.price)
+    expect(page).not_to have_link("#{item_2.name}")
+    expect(page).not_to have_content(item_2.inventory_count)
+    expect(page).not_to have_content(item_2.price)
   end
 end


### PR DESCRIPTION
- [X] Wrote Tests
- [X] Implemented
- [X] Reviewed


# Necessary checkmarks:
- [X] All Tests are Passing
- [X] The code will run locally

## Type of change
- [X] New feature
- [X] Bug Fix

# Implements/Fixes:
## Description of Changes: only items that are enabled are available to view on the items index page.  Additionally, this broke functionality for redirecting the path back to the items index page after an admin enables or disables a user.

closes #81 

# Check the correct boxes
- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [ ] No Tests have been changed
- [X] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [X] My code has no unused/commented out code
- [X] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:
